### PR TITLE
nhs-pattern-library-site: cache responses from the api between builds for 24h to reduce number of requests made

### DIFF
--- a/nhs-pattern-library-site/gatsby-node.js
+++ b/nhs-pattern-library-site/gatsby-node.js
@@ -23,7 +23,15 @@ const getPage = async path => {
 
 exports.createPages = async ({ actions: { createPage }, cache }) => {
   // List of paths to fetch from the API and create pages from
-  const paths = ["conditions/lung-cancer"]
+  const paths = [
+    "conditions/lung-cancer",
+    "conditions/lung-cancer/symptoms",
+    "conditions/lung-cancer/causes",
+    "conditions/lung-cancer/diagnosis",
+    "conditions/lung-cancer/treatment",
+    "conditions/lung-cancer/living-with",
+    "conditions/lung-cancer/prevention",
+  ]
 
   const cachePages = await Promise.all(
     paths.map(async path => {


### PR DESCRIPTION
Fixes #5

This isn't as much of a problem as I originally thought - it turns out `createPages` is only called once when you start `gatsby develop` and not on every reload. But this will still save requests when calling `gatsby build` multiple times.